### PR TITLE
Don't overwrite serviceContext in case of error if it's already defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,18 @@ Also, the error log entry for stackdriver requires us to set:
   },
 ```
 
-We will use the `name` configured as `serviceContext.name`.
+We will use the `name` configured as `serviceContext.name`. If `serviceContext` has already been defined, like below, we don't overwrite it.
+
+```ts
+const logger = Bunyan.createLogger({
+  name: 'MyLogName',
+  streams: [createStream()],
+  serviceContext: {
+    service: 'MyService',
+    version: '0.0.1'
+  }
+});
+```
 
 Thanks to this, you can track your error ocurrences in https://cloud.google.com/error-reporting/
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -71,9 +71,12 @@ export class StackdriverTransformer extends Transform {
 
     if (err && err.stack) {
       baseEntry.message = err.stack;
-      baseEntry.serviceContext = {
-        service: record.name,
-      };
+      if (!baseEntry.serviceContext) {
+        baseEntry.serviceContext = {
+          service: record.name,
+        };
+      }
+
     }
 
     if (req) {


### PR DESCRIPTION
In order to get version information digested by Google Error Reporting, the `serviceContext` object needs to contain `version` key with the value defining the version. Details here https://cloud.google.com/error-reporting/docs/formatting-error-messages.
At the moment, this package overwrites the `serviceContext` in case of errors. 

With this change, the automatic use of name for would be possible but in case the `serviceContext` would have already been defined, we shouldn't overwrite it.

If there's some other way you would like to handle this case, I'm very happy to adapt and continue discussion. Thank you for building and publishing this package in the first place.